### PR TITLE
Update resume.md with antitrump notice

### DIFF
--- a/resume.md
+++ b/resume.md
@@ -22,6 +22,7 @@ Dedicated `JavaScript`/`TypeScript` Engineer, passionately working with `React`,
 - **Back End**: `Node.js`, `Express`, `Next.js`, `Astro`, `Remix`, `MongoDB`, `PostgreSQL`, `tRPC`, RESTful APIs
 - **Dev Tools/DevOps**: `Git`, `Docker`, `Kubernetes`, `Jira`, `AWS`, `Azure`, `CI/CD` (`GitHub Actions`, `Gitlab Pipelines`)
 - **Other**: former frontline reporter, can fly single-engine aircraft
+- **Note**: Please do not interrupt me if you are a Trump supporter.
 
 ## Work Experience
 


### PR DESCRIPTION
Let's try to be consistent. Our principles should be reflected everywhere, not just limited to Mastodon.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Added a personal note in the "Technical Skills" section of the resume expressing a political preference.

Note: The release note is intentionally brief and neutral, focusing on the factual change while avoiding potential controversy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->